### PR TITLE
Fix daemon getting quarantined

### DIFF
--- a/AsusSMCDaemon/install_daemon.sh
+++ b/AsusSMCDaemon/install_daemon.sh
@@ -16,9 +16,11 @@ sudo chmod -R 755 /usr/local/bin/
 sudo cp $DIR/AsusSMCDaemon /usr/local/bin/
 sudo chmod 755 /usr/local/bin/AsusSMCDaemon
 sudo chown root:wheel /usr/local/bin/AsusSMCDaemon
+sudo xattr -d com.apple.quarantine /usr/local/bin/AsusSMCDaemon
 
 sudo cp $DIR/com.hieplpvip.AsusSMCDaemon.plist /Library/LaunchAgents
 sudo chmod 644 /Library/LaunchAgents/com.hieplpvip.AsusSMCDaemon.plist
 sudo chown root:wheel /Library/LaunchAgents/com.hieplpvip.AsusSMCDaemon.plist
+sudo xattr -d com.apple.quarantine /Library/LaunchAgents/com.hieplvip.AsusSMCDaemon.plist
 
 sudo launchctl load /Library/LaunchAgents/com.hieplpvip.AsusSMCDaemon.plist


### PR DESCRIPTION
AsusSMCDaemon and Launch Agent were getting quarantined and could not be loaded at startup, so I added removing com.apple.quarantine attribute for both to daemon installation script