### PR TITLE
Remove setPowerState method for kext to load

### DIFF
--- a/AsusSMC/AsusSMC.hpp
+++ b/AsusSMC/AsusSMC.hpp
@@ -255,7 +255,6 @@ protected:
 private:
     void subscribePowerEvents(IOService *provider);
 
-    virtual IOReturn setPowerState(unsigned long powerStateOrdinal, IOService* whatDevice);
 };
 
 #endif //_AsusSMC_hpp

--- a/AsusSMC/AsusSMC.hpp
+++ b/AsusSMC/AsusSMC.hpp
@@ -251,10 +251,6 @@ protected:
      *  @param post  post an SMC notification
      */
     bool refreshSensor(bool post);
-
-private:
-    void subscribePowerEvents(IOService *provider);
-
 };
 
 #endif //_AsusSMC_hpp


### PR DESCRIPTION
Removed the unimplemented virtual method from the header for kext to load correctly.